### PR TITLE
update stale URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ plugins) may be added to tests_require and will be downloaded and
 required by the session before invoking pytest.
 
 See the `jaraco.collections
-<https://bitbucket.org/jaraco/jaraco.collections/>`_ project
+<https://github.com/jaraco/jaraco.collections>`_ project
 for real-world usage.
 
 Standalone Example

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup_params = dict(
 	description="Invoke py.test as distutils command with dependency "
 		"resolution.",
 	long_description=long_description,
-	url="https://bitbucket.org/pytest-dev/pytest-runner",
+	url="https://github.com/pytest-dev/pytest-runner",
 	py_modules=['ptr'],
 	install_requires=[
 	],


### PR DESCRIPTION
The jaraco.collections and pytest-runner projects have moved to github.