### PR TITLE
prevent mutating opts while iterating

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -165,7 +165,7 @@ class PyTest(orig.test):
 			'find_links', 'site_dirs', 'index_url', 'optimize',
 			'site_dirs', 'allow_hosts'
 		)
-		for key in opts.keys():
+		for key in list(opts.keys()):
 			if key not in keep:
 				del opts[key]   # don't use any other settings
 		if main_dist.dependency_links:


### PR DESCRIPTION
Mutating a dict while iterating over its keys causes a RuntimeError
in python 3.  This update creates a list of keys to iterate over.