### PR TITLE
Fix comment for new black

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -38,8 +38,10 @@ class CustomizedDist(Distribution):
     index_url = None
 
     def fetch_build_egg(self, req):
-        """ Specialized version of Distribution.fetch_build_egg
-        that respects respects allow_hosts and index_url. """
+        """
+        Specialized version of Distribution.fetch_build_egg
+        that respects respects allow_hosts and index_url.
+        """
         from setuptools.command.easy_install import easy_install
 
         dist = Distribution({'script_args': ['easy_install']})


### PR DESCRIPTION
```
=================================== FAILURES ===================================
______________________________ Black format check ______________________________
--- /build/python-pytest-runner/src/pytest-runner-5.2/ptr.py	2020-11-13 07:18:37 +0000
+++ /build/python-pytest-runner/src/pytest-runner-5.2/ptr.py	2020-11-13 07:18:53.468230 +0000
@@ -36,12 +36,12 @@
 
     allow_hosts = None
     index_url = None
 
     def fetch_build_egg(self, req):
-        """ Specialized version of Distribution.fetch_build_egg
-        that respects respects allow_hosts and index_url. """
+        """Specialized version of Distribution.fetch_build_egg
+        that respects respects allow_hosts and index_url."""
         from setuptools.command.easy_install import easy_install
 
         dist = Distribution({'script_args': ['easy_install']})
         dist.parse_config_files()
         opts = dist.get_option_dict('easy_install')
```