### PR TITLE
test_egg_fetcher: use newer setuptools on Python 3.10

### DIFF
--- a/tests/test_ptr.py
+++ b/tests/test_ptr.py
@@ -44,6 +44,8 @@ setuptools_reqs = (
     ['setuptools', 'setuptools==27.3.0', 'setuptools==32.3.1', 'setuptools==36.3.0']
     if sys.version_info < (3, 7)
     else ['setuptools', 'setuptools==38.4.1']
+    if sys.version_info < (3, 10)
+    else ['setuptools', 'setuptools==49.0.0']
 )
 args_variants = ['', '--extras']
 


### PR DESCRIPTION
setuptools==49.0.0 appears to be the first version compatible with
Python 3.10 -- earlier versions either misdetect the minor version
or try to import MutableMapping from collections which dropped its
deprecated aliases to Collections Abstract Base Classes (bpo-37324).